### PR TITLE
Messages for deprecated commands

### DIFF
--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -48,32 +48,32 @@ class ListVerb(VerbExtensionPoint):
             '--topological-graph', '-g',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph`')
+            help='Obsolete, use `colcon graph`')
         group.add_argument(
             '--topological-graph-dot',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph --dot`')
+            help='Obsolete, use `colcon graph --dot`')
         parser.add_argument(
             '--topological-graph-density',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph --density`')
+            help='Obsolete, use `colcon graph --density`')
         parser.add_argument(
             '--topological-graph-legend',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph --legend`')
+            help='Obsolete, use `colcon graph --legend`')
         parser.add_argument(
             '--topological-graph-dot-cluster',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph --dot-cluster`')
+            help='Obsolete, use `colcon graph --dot-cluster`')
         parser.add_argument(
             '--topological-graph-dot-include-skipped',
             action='store_true',
             default=False,
-            help='Deprecated, use `colcon graph --dot-include-skipped`')
+            help='Obsolete, use `colcon graph --dot-include-skipped`')
 
     def main(self, *, context):  # noqa: D102
         args = context.args
@@ -89,28 +89,28 @@ class ListVerb(VerbExtensionPoint):
         if args.topological_graph:
             print('[colcon list -g] has been deprecated, '
                   'please use [colcon graph]')
-            return
+            return 1
         elif args.topological_graph_dot:
             print('[colcon list --topological-graph-dot] has been deprecated, '
                   'please use [colcon graph --dot]')
-            return
+            return 1
         elif args.topological_graph_density:
             print('[colcon list --topological-graph-density] has been '
                   'deprecated, please use [colcon graph --density]')
-            return
+            return 1
         elif args.topological_graph_legend:
             print('[colcon list --topological-graph-legend] has been '
                   'deprecated, please use [colcon graph --legend]')
-            return
+            return 1
         elif args.topological_graph_dot_cluster:
             print('[colcon list --topological-graph-dot-cluster] has been '
                   'deprecated, please use [colcon graph --dot-cluster]')
-            return
+            return 1
         elif args.topological_graph_dot_include_skipped:
             print('[colcon list --topological-graph-dot-include-skipped] has '
                   'been deprecated, please use [colcon graph '
                   '--dot-include-skipped]')
-            return
+            return 1
 
         if not args.topological_order:
             decorators = sorted(

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -111,30 +111,39 @@ class ListVerb(VerbExtensionPoint):
 
         select_package_decorators(args, decorators)
 
+        if args.topological_graph or args.topological_graph_dot:
+            additional_options = []
+            if args.topological_graph_density:
+                additional_options.append('--density')
+            if args.topological_graph_legend:
+                additional_options.append('--legend')
+            if args.topological_graph_dot:
+                if args.topological_graph_dot_cluster:
+                    additional_options.append('--dot-cluster')
+                if args.topological_graph_dot_include_skipped:
+                    additional_options.append('--dot-include-skipped')
+            additional_options = ''.join(' ' + x for x in additional_options)
         if args.topological_graph:
-            print('[colcon list -g] is obsolete, '
-                  'please use [colcon graph]')
-            return 1
-        elif args.topological_graph_dot:
-            print('[colcon list --topological-graph-dot] is obsolete, '
-                  'please use [colcon graph --dot]')
-            return 1
-        elif args.topological_graph_density:
-            print('[colcon list --topological-graph-density] is '
-                  'obsolete, please use [colcon graph --density]')
-            return 1
-        elif args.topological_graph_legend:
-            print('[colcon list --topological-graph-legend] is '
-                  'obsolete, please use [colcon graph --legend]')
-            return 1
-        elif args.topological_graph_dot_cluster:
-            print('[colcon list --topological-graph-dot-cluster] is '
-                  'obsolete, please use [colcon graph --dot-cluster]')
-            return 1
-        elif args.topological_graph_dot_include_skipped:
-            print('[colcon list --topological-graph-dot-include-skipped] is '
-                  'obsolete, please use [colcon graph --dot-include-skipped]')
-            return 1
+            return 'The {args.verb_name} options --topological-graph / -g ' \
+                'are obsolete, instead use `{context.command_name} graph' \
+                '{additional_options}`'.format_map(locals())
+        if args.topological_graph_dot:
+            return 'The {args.verb_name} option --topological-graph-dot is ' \
+                'obsolete, instead use `{context.command_name} graph --dot' \
+                '{additional_options}`'.format_map(locals())
+        if args.topological_graph_density:
+            return 'The option --topological-graph-density must be used ' \
+                'together with either --topological-graph or ' \
+                '--topological-graph-dot'
+        if args.topological_graph_legend:
+            return 'The option --topological-graph-legend must be used ' \
+                ' with either --topological-graph or --topological-graph-dot'
+        if args.topological_graph_dot_cluster:
+            return 'The option --topological-graph-dot-cluster must be used ' \
+                'together with --topological-graph-dot'
+        if args.topological_graph_dot_include_skipped:
+            return 'The option --topological-graph-dot-include-skipped must ' \
+                'be used together with --topological-graph-dot'
 
         if not args.topological_order:
             decorators = sorted(

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -44,6 +44,36 @@ class ListVerb(VerbExtensionPoint):
             action='store_true',
             default=False,
             help='Output only the path of each package but not the name')
+        group.add_argument(
+            '--topological-graph', '-g',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph`')
+        group.add_argument(
+            '--topological-graph-dot',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph --dot`')
+        parser.add_argument(
+            '--topological-graph-density',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph --density`')
+        parser.add_argument(
+            '--topological-graph-legend',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph --legend`')
+        parser.add_argument(
+            '--topological-graph-dot-cluster',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph --dot-cluster`')
+        parser.add_argument(
+            '--topological-graph-dot-include-skipped',
+            action='store_true',
+            default=False,
+            help='Deprecated, use `colcon graph --dot-include-skipped`')
 
     def main(self, *, context):  # noqa: D102
         args = context.args
@@ -55,6 +85,30 @@ class ListVerb(VerbExtensionPoint):
             descriptors, recursive_categories=('run', ))
 
         select_package_decorators(args, decorators)
+
+        if args.topological_graph:
+            print('[colcon list -g] has been deprecated, please use [colcon graph]')
+            return
+        elif args.topological_graph_dot:
+            print('[colcon list --topological-graph-dot] has been deprecated, '
+                  'please use [colcon graph --dot]')
+            return
+        elif args.topological_graph_density:
+            print('[colcon list --topological-graph-density] has been deprecated, '
+                  'please use [colcon graph --density]')
+            return
+        elif args.topological_graph_legend:
+            print('[colcon list --topological-graph-legend] has been deprecated, '
+                  'please use [colcon graph --legend]')
+            return
+        elif args.topological_graph_dot_cluster:
+            print('[colcon list --topological-graph-dot-cluster] has been deprecated, '
+                  'please use [colcon graph --dot-cluster]')
+            return
+        elif args.topological_graph_dot_include_skipped:
+            print('[colcon list --topological-graph-dot-include-skipped] has been deprecated, '
+                  'please use [colcon graph --dot-include-skipped]')
+            return
 
         if not args.topological_order:
             decorators = sorted(

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -133,7 +133,7 @@ class ListVerb(VerbExtensionPoint):
                 '{additional_options}`'.format_map(locals())
         if args.topological_graph_density:
             return 'The option --topological-graph-density must be used ' \
-                'together with either --topological-graph'
+                'together with --topological-graph'
         if args.topological_graph_legend:
             return 'The option --topological-graph-legend must be used ' \
                 ' with either --topological-graph or --topological-graph-dot'

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -87,29 +87,28 @@ class ListVerb(VerbExtensionPoint):
         select_package_decorators(args, decorators)
 
         if args.topological_graph:
-            print('[colcon list -g] has been deprecated, '
+            print('[colcon list -g] is obsolete, '
                   'please use [colcon graph]')
             return 1
         elif args.topological_graph_dot:
-            print('[colcon list --topological-graph-dot] has been deprecated, '
+            print('[colcon list --topological-graph-dot] is obsolete, '
                   'please use [colcon graph --dot]')
             return 1
         elif args.topological_graph_density:
-            print('[colcon list --topological-graph-density] has been '
-                  'deprecated, please use [colcon graph --density]')
+            print('[colcon list --topological-graph-density] is '
+                  'obsolete, please use [colcon graph --density]')
             return 1
         elif args.topological_graph_legend:
-            print('[colcon list --topological-graph-legend] has been '
-                  'deprecated, please use [colcon graph --legend]')
+            print('[colcon list --topological-graph-legend] is '
+                  'obsolete, please use [colcon graph --legend]')
             return 1
         elif args.topological_graph_dot_cluster:
-            print('[colcon list --topological-graph-dot-cluster] has been '
-                  'deprecated, please use [colcon graph --dot-cluster]')
+            print('[colcon list --topological-graph-dot-cluster] is '
+                  'obsolete, please use [colcon graph --dot-cluster]')
             return 1
         elif args.topological_graph_dot_include_skipped:
-            print('[colcon list --topological-graph-dot-include-skipped] has '
-                  'been deprecated, please use [colcon graph '
-                  '--dot-include-skipped]')
+            print('[colcon list --topological-graph-dot-include-skipped] is '
+                  'obsolete, please use [colcon graph --dot-include-skipped]')
             return 1
 
         if not args.topological_order:

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -113,15 +113,15 @@ class ListVerb(VerbExtensionPoint):
 
         if args.topological_graph or args.topological_graph_dot:
             additional_options = []
-            if args.topological_graph_density:
-                additional_options.append('--density')
-            if args.topological_graph_legend:
-                additional_options.append('--legend')
             if args.topological_graph_dot:
                 if args.topological_graph_dot_cluster:
                     additional_options.append('--dot-cluster')
                 if args.topological_graph_dot_include_skipped:
                     additional_options.append('--dot-include-skipped')
+            elif args.topological_graph_density:
+                additional_options.append('--density')
+            if args.topological_graph_legend:
+                additional_options.append('--legend')
             additional_options = ''.join(' ' + x for x in additional_options)
         if args.topological_graph:
             return 'The {args.verb_name} options --topological-graph / -g ' \
@@ -133,8 +133,7 @@ class ListVerb(VerbExtensionPoint):
                 '{additional_options}`'.format_map(locals())
         if args.topological_graph_density:
             return 'The option --topological-graph-density must be used ' \
-                'together with either --topological-graph or ' \
-                '--topological-graph-dot'
+                'together with either --topological-graph'
         if args.topological_graph_legend:
             return 'The option --topological-graph-legend must be used ' \
                 ' with either --topological-graph or --topological-graph-dot'

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -87,27 +87,29 @@ class ListVerb(VerbExtensionPoint):
         select_package_decorators(args, decorators)
 
         if args.topological_graph:
-            print('[colcon list -g] has been deprecated, please use [colcon graph]')
+            print('[colcon list -g] has been deprecated, '
+                  'please use [colcon graph]')
             return
         elif args.topological_graph_dot:
             print('[colcon list --topological-graph-dot] has been deprecated, '
                   'please use [colcon graph --dot]')
             return
         elif args.topological_graph_density:
-            print('[colcon list --topological-graph-density] has been deprecated, '
-                  'please use [colcon graph --density]')
+            print('[colcon list --topological-graph-density] has been '
+                  'deprecated, please use [colcon graph --density]')
             return
         elif args.topological_graph_legend:
-            print('[colcon list --topological-graph-legend] has been deprecated, '
-                  'please use [colcon graph --legend]')
+            print('[colcon list --topological-graph-legend] has been '
+                  'deprecated, please use [colcon graph --legend]')
             return
         elif args.topological_graph_dot_cluster:
-            print('[colcon list --topological-graph-dot-cluster] has been deprecated, '
-                  'please use [colcon graph --dot-cluster]')
+            print('[colcon list --topological-graph-dot-cluster] has been '
+                  'deprecated, please use [colcon graph --dot-cluster]')
             return
         elif args.topological_graph_dot_include_skipped:
-            print('[colcon list --topological-graph-dot-include-skipped] has been deprecated, '
-                  'please use [colcon graph --dot-include-skipped]')
+            print('[colcon list --topological-graph-dot-include-skipped] has '
+                  'been deprecated, please use [colcon graph '
+                  '--dot-include-skipped]')
             return
 
         if not args.topological_order:

--- a/colcon_package_information/verb/list.py
+++ b/colcon_package_information/verb/list.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.command import get_prog_name
 from colcon_core.package_selection import add_arguments \
     as add_packages_arguments
 from colcon_core.package_selection import get_package_descriptors
@@ -44,36 +45,60 @@ class ListVerb(VerbExtensionPoint):
             action='store_true',
             default=False,
             help='Output only the path of each package but not the name')
-        group.add_argument(
+
+        group = parser.add_argument_group('Obsolete arguments')
+        command_name = get_prog_name()
+        self._add_obsolete_argument(
+            group,
             '--topological-graph', '-g',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph`')
-        group.add_argument(
+            help='Instead use `{command_name} graph`'.format_map(locals()))
+        self._add_obsolete_argument(
+            group,
             '--topological-graph-dot',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph --dot`')
-        parser.add_argument(
+            help='Instead use `{command_name} graph --dot`'
+                 .format_map(locals()))
+        self._add_obsolete_argument(
+            group,
             '--topological-graph-density',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph --density`')
-        parser.add_argument(
+            help='Instead use `{command_name} graph --density`'
+                 .format_map(locals()))
+        self._add_obsolete_argument(
+            group,
             '--topological-graph-legend',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph --legend`')
-        parser.add_argument(
+            help='Instead use `{command_name} graph --legend`'
+                 .format_map(locals()))
+        self._add_obsolete_argument(
+            group,
             '--topological-graph-dot-cluster',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph --dot-cluster`')
-        parser.add_argument(
+            help='Instead use `{command_name} graph --dot --dot-cluster`'
+                 .format_map(locals()))
+        self._add_obsolete_argument(
+            group,
             '--topological-graph-dot-include-skipped',
             action='store_true',
             default=False,
-            help='Obsolete, use `colcon graph --dot-include-skipped`')
+            help='Instead use `{command_name} graph --dot '
+                 '--dot-include-skipped`'.format_map(locals()))
+
+    def _add_obsolete_argument(self, group, *args, **kwargs):
+        arg = group.add_argument(*args, **kwargs)
+        try:
+            from argcomplete.completers import SuppressCompleter
+        except ImportError:
+            pass
+        else:
+            arg.completer = SuppressCompleter()
+        return arg
 
     def main(self, *, context):  # noqa: D102
         args = context.args

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core
+  colcon-core>=0.5.2
 packages = find:
 tests_require =
   flake8>=3.6.0

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-package-information]
 No-Python2:
-Depends3: python3-colcon-core
+Depends3: python3-colcon-core (>= 0.5.2)
 Suite: xenial bionic focal stretch buster
 X-Python3-Version: >= 3.5

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,6 +1,8 @@
 apache
+argcomplete
 colcon
 commonpath
+completers
 decos
 defaultdict
 deps


### PR DESCRIPTION
Some options were removed on https://github.com/colcon/colcon-package-information/pull/23 without a deprecation message with the assumption (https://github.com/colcon/colcon-package-information/pull/23#issuecomment-546430735) that the options were not being used.

But in fact, `colcon list -g` specifically seems to be a popular command being referenced in various [documentations](https://www.google.com/search?q=%22colcon%20list%20-g%22), in several languages :wink:

This PR prints the new commands for users trying to use the old ones. I'm not sure if there's a migration guide where this change should also be documented?