### PR TITLE
improve performance by reducing logging while checking version constraints

### DIFF
--- a/colcon_package_information/package_augmentation/check_dependency_constraint.py
+++ b/colcon_package_information/package_augmentation/check_dependency_constraint.py
@@ -65,22 +65,21 @@ class CheckDependencyConstraintPackageAugmentation(
             'version_gte': (gte, 'greater than or equal to'),
             'version_gt': (operator.gt, 'greater than'),
         }
-        logger.log(
-            1,
-            desc.name + ' depends on ' + dep.name +
-            ' which has version ' + dep_desc.metadata['version'] +
-            ': constraints ' + str(dep.metadata))
         for key, value in dep.metadata.items():
             # only consider version operator metadata
             if key not in operators:
                 continue
+            op, msg = operators[key]
             try:
                 version_constraint = parse_version(value)
             except Exception:
+                logger.error(
+                    "Failed to parse version '" + value + "' with " +
+                    "constraint '" + msg + "' for dependency " + dep.name +
+                    ' in package ' + desc.name)
                 # skip check if the version fails to parse
                 continue
 
-            op, msg = operators[key]
             if not op(dep_version, version_constraint):
                 logger.warning(
                     desc.name + ' depends on ' + dep.name +


### PR DESCRIPTION
The patch removes a level-1 log message for every dependency - even if it doesn't have any version constraints. It also adds an explicit error message if the version of the constraint can't be parsed (which was silently ignored before).

On a large workspace with ~300 pkgs this patch reduces the time for `colcon list` from ~0.9s to ~0.85s.

Profiling the `_check_version_constraints()` function shows that from ~220ms before ~200ms where spent in `log`. With this change the `log()` part is completely eliminated.