### PR TITLE
Fix 'info' verb output randomness

### DIFF
--- a/colcon_package_information/verb/info.py
+++ b/colcon_package_information/verb/info.py
@@ -4,13 +4,12 @@
 import argparse
 import sys
 
-from colcon_core.package_decorator import add_recursive_dependencies
-from colcon_core.package_decorator import get_decorators
 from colcon_core.package_selection import add_arguments \
     as add_packages_arguments
 from colcon_core.package_selection import get_package_descriptors
 from colcon_core.package_selection import select_package_decorators
 from colcon_core.plugin_system import satisfies_version
+from colcon_core.topological_order import topological_order_packages
 from colcon_core.verb import VerbExtensionPoint
 
 
@@ -39,9 +38,8 @@ class InfoVerb(VerbExtensionPoint):
     def main(self, *, context):  # noqa: D102
         descriptors = get_package_descriptors(
             context.args, additional_argument_names=['*'])
-        decorators = get_decorators(descriptors)
-        add_recursive_dependencies(
-            decorators, recursive_categories=('run', ))
+        decorators = topological_order_packages(
+            descriptors, recursive_categories=('run', ))
         select_package_decorators(context.args, decorators)
 
         if context.args.package_names:


### PR DESCRIPTION
Fixes https://github.com/colcon/colcon-core/issues/443

Without this PR, if we compare the output of multiple runs of `colcon info --packages-up-to some_package_with_a_fair_number_of_recursive_dependencies`, we see that it's all different. With this PR, it's all the same output. The packages in the output itself match the output of `colcon list ...`.

This is how it's done for the `list` verb and it works here: https://github.com/colcon/colcon-package-information/blob/295189f2f1d6362c331c6c3ff88e13ba28a94faa/colcon_package_information/verb/list.py#L106-L112. As the comment there says, descriptors must be in topological order before selection.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>