### PR TITLE
suppress deprecation warning in flake8

### DIFF
--- a/colcon_package_information/package_augmentation/check_dependency_constraint.py
+++ b/colcon_package_information/package_augmentation/check_dependency_constraint.py
@@ -26,9 +26,9 @@ class CheckDependencyConstraintPackageAugmentation(
         satisfies_version(
             PackageAugmentationExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
-    def augment_packages(
+    def augment_packages(  # noqa: D102
         self, descs, *, additional_argument_names=None
-    ):  # noqa: D102
+    ):
         descs_dict = {desc.name: desc for desc in descs}
         for name, desc in descs_dict.items():
             deps = desc.get_dependencies()

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ zip_safe = true
 [tool:pytest]
 filterwarnings =
     error
+    # Suppress deprecation warning in flake8
+    ignore:SelectableGroups dict interface is deprecated::flake8
 junit_suite_name = colcon-package-information
 
 [options.entry_points]


### PR DESCRIPTION
Introduced by python/importlib_metadata # 298.

Also move `noqa` comment to pass with latest `flake8`.